### PR TITLE
Hotfix ticket#167: Prevent 500's internal error from group edit 

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -11,7 +11,8 @@ NEWS
 0.8.16 (unreleased)
 ------
 
-* Fix traceback in selinux when creating homedirs in fasClient
+* Fix traceback in selinux when creating homedirs in fasClient.
+* Fix 500's error from group edit if no group_type has been set.
 
 ------
 0.8.15

--- a/fas/group.py
+++ b/fas/group.py
@@ -333,6 +333,11 @@ class Group(controllers.Controller):
         group = Groups.by_name(groupname)
 
         changed = []
+        #TODO: check any mandatory fields
+        if not group_type:
+            turbogears.flash(_("Group type cannot by empty!"))
+            turbogears.redirect('/group/edit/%s' % group.name)
+
         if not can_edit_group(person, group):
             turbogears.flash(_("You cannot edit '%s'.") % group.name)
             turbogears.redirect('/group/view/%s' % group.name)

--- a/fas/help.py
+++ b/fas/help.py
@@ -18,6 +18,7 @@
 #
 # Author(s): Ricky Zhou <ricky@fedoraproject.org>
 #            Mike McGrath <mmcgrath@redhat.com>
+#            Xavier Lamien <xlamien@fedoraproject.org>
 #
 import turbogears
 from turbogears import config, controllers, expose
@@ -51,7 +52,7 @@ class Help(controllers.Controller):
             'group_name':           [_('Group Name'), _('''<p>The name of the group you'd like to create.  It should be lowercase alphanumeric though '-' and '_' are allowed</p>''')],
             'group_display_name':   [_('Display Name'), _('''<p>More human readable name of the group</p>''')],
             'group_owner':          [_('Group Owner'), _('''<p>The name of the owner who will run this group</p>''')],
-            'group_type':           [_('Group Type'), _('''<p>Normally it is safe to leave this blank.  Though some values include 'tracking', 'shell', 'cvs', 'git', 'hg', 'svn', and 'mtn'.  This value only really matters if the group is to end up getting shell access or commit access somewhere like fedorahosted.</p>''')],
+            'group_type':           [_('Group Type'), _('''<p>Mandatory field. Available values are 'tracking', 'shell', 'cvs', 'git', 'hg', 'svn', and 'mtn'. This value only really matters if the group is to end up getting shell access or commit access somewhere like fedorahosted.</p>''')],
             'group_url':            [_('Group URL (Optional)'), _('''<p>A URL or wiki page for the group (for example, <a href="https://fedoraproject.org/wiki/Infrastructure">https://fedoraproject.org/wiki/Infrastructure</a>).</p>''')],
             'group_mailing_list':     [_('Group Mailing List (Optional)'), _('''<p>A mailing list for the group (for example, fedora-infrastructure-list@redhat.com).</p>''')],
             'group_mailing_list_url': [_('Group Mailing List URL (Optional)'), _('''<p>A URL for the group's mailing list (for example, <a href="http://www.redhat.com/mailman/listinfo/fedora-infrastructure-list">http://www.redhat.com/mailman/listinfo/fedora-infrastructure-list</a>).</p>''')],

--- a/fas2.sql
+++ b/fas2.sql
@@ -16,6 +16,7 @@
 -- Author(s): Toshio Kuratomi <tkuratom@redhat.com>
 --            Ricky Zhou <ricky@fedoraproject.org>
 --            Mike McGrath <mmcgrath@redhat.com>
+--            Xavier Lamien <laxathom@fedoraproject.org>
 --
 create database fas2 encoding = 'UTF8';
 \c fas2
@@ -112,7 +113,7 @@ CREATE TABLE groups (
     irc_channel TEXT,
     irc_network TEXT,
     owner_id INTEGER NOT NULL REFERENCES people(id),
-    group_type VARCHAR(16),
+    group_type VARCHAR(16) NOT NULL,
     needs_sponsor BOOLEAN DEFAULT FALSE,
     user_can_remove BOOLEAN DEFAULT TRUE,
     invite_only BOOLEAN DEFAULT FALSE,


### PR DESCRIPTION
We actually have no check on empty field from group edit page.
If people leave a  field blank, the web page will crash from an transaction rollback as
we don't allow NULL string from group_type's column in DB. 
