### PR TITLE
Hotfix/fix fpca signing fedmsg bug

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -8,6 +8,12 @@ NEWS
 :Version: 0.8.16
 
 ------
+0.8.17 (not yet released)
+------
+
+* Fix a fpca signing bug
+
+------
 0.8.16
 ------
 

--- a/fas/fpca.py
+++ b/fas/fpca.py
@@ -338,7 +338,7 @@ Thanks!
             person.apply(group, person) # Apply for the new group
             session.flush()
 
-            fas.fas.fedmsgshimshim.send_message(topic="group.member.apply", msg={
+            fas.fedmsgshim.send_message(topic="group.member.apply", msg={
                 'agent': person.username,
                 'user': person.username,
                 'group': group.name,


### PR DESCRIPTION
The first time signing the fpca was failing because of a typo in calling fedmsgshim.send_message().  fixed.
