### PR TITLE
Eliminate one occurance of the N+1 Query problem.

### DIFF
--- a/fas/group.py
+++ b/fas/group.py
@@ -37,6 +37,7 @@ import cherrypy
 import sqlalchemy
 from sqlalchemy import select, func
 from sqlalchemy.sql import and_
+from sqlalchemy.orm import eagerload
 
 import re
 
@@ -184,7 +185,8 @@ class Group(controllers.Controller):
         unsponsored = PersonRoles.query.join('group').join('member',
             aliased=True).outerjoin('sponsor', aliased=True).filter(
             and_(Groups.name==groupname,
-                PersonRoles.role_status=='unapproved')).order_by(sort_map[order_by])
+                PersonRoles.role_status=='unapproved')).options(
+                    eagerload('member')).order_by(sort_map[order_by])
         unsponsored.json_props = {'PersonRoles': ['member']}
         members = PersonRoles.query.join('group').join('member', aliased=True).filter(
             People.username.like('%')


### PR DESCRIPTION
This removes one instance of the "N+1" query problem, where we perform a query
to obtain a list of other things to query on, then query all of them
individually.

In this scenario, we wanted to obtain information about every member of the
group whose status was 'unapproved'. So we ran a query that gets a list of
all members in the person_roles table whose role_status was 'unapproved' for a
particular group_id.

We then performed a `select` query on each of the resulting users to obtain
information about them for rendering.

With this change, we pull all of the information in one query, which means
much less overhead in terms of round trips to the db servers, especially in
production where our db servers are not on localhost.

This is a sampling of the difference, for a group with 136 unapproved members.

```
$ grep -ci select /tmp/without-change.txt
191
$ grep -ci select /tmp/with-change.txt
56
```

The page still renders the list of people in the sponsorship queue just fine.
