### PR TITLE
More optimizations for group view.

### DIFF
--- a/fas/templates/group/view.html
+++ b/fas/templates/group/view.html
@@ -110,9 +110,9 @@
       <h3>${_('Sponsorship Queue')}</h3>
       ${member_table(sponsor_queue, group, person)}
     </div>
-    <div py:if="10 >= len(members)" >
+    <div py:if="10 >= members.count()" >
         <h3>${_('Members')}</h3>
-        ${member_table(members, group, person)}
+        ${member_table(list(members), group, person)}
     </div>
   </body>
 </html>


### PR DESCRIPTION
In the `view()` method, we were hitting the database with a really expensive
query for large groups (such as cla_fpca), converting it to a list (so storing
it in memory), then only rendering the results if the list contained less than
10 elements.

This is a semi-rare case where it makes sense to do a `count()` query first,
then act on the results if the result of the count query is < 10.

For consistency, we keep the conditional in the template, but pass the template
object a query object, rather than a list. We only convert to a list (which is
what performs the actual query) if the conditional passes. The conditional is
what issues the count query.
