### PR TITLE
Only show the security question field when the person is viewing their o...

### DIFF
--- a/fas/templates/user/view.html
+++ b/fas/templates/user/view.html
@@ -76,17 +76,19 @@
         <!-- Note: password is changable so we don't hide it if it's
         - unavailable
         - -->
-        <dt>${_('Security question: ')}</dt>
-        <py:if test="personal">
-          <dd>${person.security_question}&nbsp;  <a href="${tg.url('/user/changequestion')}">${_('(change)')}</a></dd>
-        </py:if>
-        <py:if test="not personal and admin">
-          <dd>
-            <div>
-              <span py:if="person.security_question" class="approved">${_('Active')}</span>
-              <span py:if="not person.security_question" class="unapproved">${_('Inactive')}</span>
-            </div>
-          </dd>
+        <py:if test="personal or admin">
+          <dt>${_('Security question: ')}</dt>
+          <py:if test="personal">
+            <dd>${person.security_question}&nbsp;  <a href="${tg.url('/user/changequestion')}">${_('(change)')}</a></dd>
+          </py:if>
+          <py:if test="not personal and admin">
+            <dd>
+              <div>
+                <span py:if="person.security_question" class="approved">${_('Active')}</span>
+                <span py:if="not person.security_question" class="unapproved">${_('Inactive')}</span>
+              </div>
+            </dd>
+          </py:if>
         </py:if>
         <py:if test="personal or admin">
           <dt>${_('Password:')}</dt>


### PR DESCRIPTION
Only show the security question field when the person is viewing their own account, or when an admin is viewing their account.

This is not a security issue - we were only showing the field, not the question.
It's just a UI fix.

Before:

<img src="http://i.imgur.com/vI9oZwv.png" />

After:

<img src="http://i.imgur.com/So9M5xK.png" />
