### PR TITLE
Bugzilla 4.4 no longer takes a list of groups in User.update (python-bugzilla API: updateperms()

### DIFF
--- a/scripts/export-bugzilla.py
+++ b/scripts/export-bugzilla.py
@@ -56,7 +56,7 @@ if __name__ == '__main__':
         if entry.action == 'r':
             # Remove the user's bugzilla group
             try:
-                server.updateperms(entry.email, 'rem', (bzGroup,))
+                server.updateperms(entry.email, 'rem', bzGroup)
             except xmlrpclib.Fault, e:
                 if e.faultCode == 504:
                     # It's okay, not having this user is equivalent to setting
@@ -78,7 +78,7 @@ if __name__ == '__main__':
                 else:
                     print 'Error:', e, entry.email, entry.person.human_name
                     raise
-            server.updateperms(entry.email, 'add', (bzGroup,))
+            server.updateperms(entry.email, 'add', bzGroup)
         else:
             print 'Unrecognized action code: %s %s %s %s %s' % (entry.action,
                     entry.email, entry.person.human_name, entry.person.username, entry.group.name)


### PR DESCRIPTION
The new bugzilla.rh.c server takes a single string for the group to assign a user to instead of a list.  This requires that we update the export-bugzilla script to send a string instead of a list.
