### PR TITLE
Hotfix/non ascii human name check

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -5,7 +5,13 @@ NEWS
 :Authors: Ricky Zhou, Mike McGrath, Toshio Kuratomi, Patrick Uiterwijk,
           Ricky Elrod
 :Date: 08 May 2013
-:Version: 0.8.17
+:Version: 0.8.18
+
+------
+0.8.18 (not yet released)
+------
+
+* Fix the human name heuristic to work with non-ascii characters
 
 ------
 0.8.17

--- a/fas/validators.py
+++ b/fas/validators.py
@@ -312,7 +312,7 @@ class ValidHumanWithOverride(validators.FancyValidator):
 
         # Check for initials, only first or last name etc.
         name = values.get(self.name_field)
-        name_regex = re.compile ( '^([A-Z]|[a-z])+\s(([A-Z]|[a-z])\.\s)*([A-Z]|[a-z])+$' )
+        name_regex = re.compile(r'^\S{2}\S*\b.*\b\S{2}\S*$', flags=re.UNICODE)
         if not name_regex.match ( name ):
             errors[self.name_field] = self.message('initial', state)
 


### PR DESCRIPTION
reported on websites mailing list: https://lists.fedoraproject.org/pipermail/websites/2013-October/011734.html

The fix is a little looser than the original (it allows digits and symbols as well as letters) but this isn't intended to be a perfect check -- just pre-screen non-legally binding names for spot.  Likely people will either heed the warning message or hit the name override anyway.
