### PR TITLE
Be careful when updating user fields.

### DIFF
--- a/fas/user.py
+++ b/fas/user.py
@@ -413,8 +413,10 @@ login with your Fedora account first):
                       'gpg_keyid', 'comments', 'locale', 'timezone',
                       'country_code', 'privacy', 'latitude', 'longitude')
             for field in fields:
-                if getattr(target, field) != locals()[field]:
-                    setattr(target, field, locals()[field])
+                old = getattr(target, field)
+                new = locals()[field]
+                if (old or new) and old != new:
+                    setattr(target, field, new)
                     changed.append(field)
 
         except TypeError, error:


### PR DESCRIPTION
In bug #42, fedmsg tells us that the user changed their gpg_keyid when they
really did not.  My guess is that this is fas updating a None value to the
empty string ('') or vice versa.

The logic here first checks that at least one of the values (`new or old`)
is True-ish before checking to see if they're different.  If at least one of
them is not false-ish _and_ they are different, then we'll set the change in
the db and publish to fedmsg.
