### PR TITLE
Adjust fasClient to load its configuration raw

### DIFF
--- a/client/fasClient
+++ b/client/fasClient
@@ -176,7 +176,7 @@ def __setup_logger__(level):
     log.addHandler(ch)
 
 try:
-    config = ConfigParser.ConfigParser()
+    config = ConfigParser.RawConfigParser()
     if os.path.exists(opts.CONFIG_FILE):
         config.read(opts.CONFIG_FILE)
     elif os.path.exists('fas.conf'):
@@ -670,7 +670,8 @@ class MakeShellAccounts(AccountSystem):
                for key_tmp in self.users[uid]['ssh_key'].split("\n"):
                    if key_tmp:
                        log.debug('Adding command to SSH entry')
-                       key.append('command="%s",%s %s' % (users[uid]['ssh_cmd'], users[uid]['ssh_options'], key_tmp))
+                       cmd = users[uid]['ssh_cmd'] % {'username': username}
+                       key.append('command="%s",%s %s' % (cmd, users[uid]['ssh_options'], key_tmp))
                key = "\n".join(key)
             else:
                key = self.users[uid]['ssh_key']


### PR DESCRIPTION
For gitolite3, we need to specify the username in the command inserted
in ~/.ssh/authorized_keys.
For this we have currently the configuration keys: ssh_restricted_app
and ssh_admin_app but we cannot set them as template using %(username)s
in it.

With this change we now can. As we fill in the command using a dictionary
python will no complain if the string does not contain %(username)s
so it should be backward compatible.

The change to read the configuration file with RawConfigParser is also
safe as afaik we do not interpolate anywhere variables based on others.
