### PR TITLE
Make JSON `CreationDate`s be in isoformat

### DIFF
--- a/fas/models/group.py
+++ b/fas/models/group.py
@@ -135,7 +135,7 @@ class Groups(Base):
                 'NeedApproval': self.need_approval,
                 'IsInviteOnly': self.invite_only,
                 'IsPrivate': self.private,
-                'CreationDate': self.created.strftime('%Y-%m-%d %H:%M'),
+                'CreationDate': self.created.isoformat(),
             }
 
         if self.group_types:

--- a/fas/models/people.py
+++ b/fas/models/people.py
@@ -158,7 +158,7 @@ class People(Base):
                 'Ircnick': self.ircnick,
                 'Avatar': self.avatar,
                 'Email': self.email,
-                'CreationDate': self.date_created.strftime('%Y-%m-%d %H:%M'),
+                'CreationDate': self.date_created.isoformat(),
                 'Status': self.status
             }
 


### PR DESCRIPTION
To be consistent with StartTimeStamp/EndTimeStamp in the general result
template. Makes parsing the dates into a date format in other
environments a bit easier since they are all the same format.

Signed-off-by: Ricky Elrod <ricky@elrod.me>