### PR TITLE
Work around Python's invalid ISO format

### DIFF
--- a/fas/api/__init__.py
+++ b/fas/api/__init__.py
@@ -3,7 +3,7 @@
 from pyramid.view import view_config
 from math import ceil
 
-from fas.utils import compute_list_pages_from
+from fas.utils import compute_list_pages_from, fix_utc_iso_format
 
 import datetime
 
@@ -23,8 +23,7 @@ class MetaData():
         # self.metadata[name + 'Result'] = {}
         self.name = name
         self.datetime = datetime.datetime
-        self.strftime = '%Y-%m-%dT%H:%M:%S%Z'
-        self.timestamp = self.datetime.utcnow().strftime(self.strftime)
+        self.timestamp = fix_utc_iso_format(self.datetime.utcnow())
 
     def set_error_msg(self, name='', text=''):
         """ Set error message into metadata's dict().
@@ -62,8 +61,7 @@ class MetaData():
             :returns: Dict object of metadata from given parameters.
         """
         self.data['StartTimeStamp'] = self.timestamp
-        self.data['EndTimeStamp'] = self.datetime.utcnow().strftime(
-            self.strftime)
+        self.data['EndTimeStamp'] = fix_utc_iso_format(self.datetime.utcnow())
 
         return self.data
 

--- a/fas/api/__init__.py
+++ b/fas/api/__init__.py
@@ -3,7 +3,7 @@
 from pyramid.view import view_config
 from math import ceil
 
-from fas.utils import compute_list_pages_from, fix_utc_iso_format
+from fas.utils import compute_list_pages_from, utc_iso_format
 
 import datetime
 
@@ -23,7 +23,7 @@ class MetaData():
         # self.metadata[name + 'Result'] = {}
         self.name = name
         self.datetime = datetime.datetime
-        self.timestamp = fix_utc_iso_format(self.datetime.utcnow())
+        self.timestamp = utc_iso_format(self.datetime.utcnow())
 
     def set_error_msg(self, name='', text=''):
         """ Set error message into metadata's dict().
@@ -61,7 +61,7 @@ class MetaData():
             :returns: Dict object of metadata from given parameters.
         """
         self.data['StartTimeStamp'] = self.timestamp
-        self.data['EndTimeStamp'] = fix_utc_iso_format(self.datetime.utcnow())
+        self.data['EndTimeStamp'] = utc_iso_format(self.datetime.utcnow())
 
         return self.data
 

--- a/fas/models/group.py
+++ b/fas/models/group.py
@@ -32,7 +32,7 @@ from fas.models import AccountPermissionType as perm
 from babel.dates import format_date
 
 import datetime
-
+from fas.utils import fix_utc_iso_format
 
 class GroupType(Base):
     __tablename__ = 'group_type'
@@ -135,7 +135,7 @@ class Groups(Base):
                 'NeedApproval': self.need_approval,
                 'IsInviteOnly': self.invite_only,
                 'IsPrivate': self.private,
-                'CreationDate': self.created.isoformat(),
+                'CreationDate': fix_utc_iso_format(self.created),
             }
 
         if self.group_types:

--- a/fas/models/group.py
+++ b/fas/models/group.py
@@ -32,7 +32,7 @@ from fas.models import AccountPermissionType as perm
 from babel.dates import format_date
 
 import datetime
-from fas.utils import fix_utc_iso_format
+from fas.utils import utc_iso_format
 
 class GroupType(Base):
     __tablename__ = 'group_type'
@@ -135,7 +135,7 @@ class Groups(Base):
                 'NeedApproval': self.need_approval,
                 'IsInviteOnly': self.invite_only,
                 'IsPrivate': self.private,
-                'CreationDate': fix_utc_iso_format(self.created),
+                'CreationDate': utc_iso_format(self.created),
             }
 
         if self.group_types:

--- a/fas/models/people.py
+++ b/fas/models/people.py
@@ -27,7 +27,7 @@ from sqlalchemy.orm import (
 
 from fas.models import AccountPermissionType as perm
 
-from fas.utils import format_datetime
+from fas.utils import format_datetime, fix_utc_iso_format
 
 import datetime
 
@@ -158,7 +158,7 @@ class People(Base):
                 'Ircnick': self.ircnick,
                 'Avatar': self.avatar,
                 'Email': self.email,
-                'CreationDate': self.date_created.isoformat(),
+                'CreationDate': fix_utc_iso_format(self.date_created),
                 'Status': self.status
             }
 

--- a/fas/models/people.py
+++ b/fas/models/people.py
@@ -27,7 +27,7 @@ from sqlalchemy.orm import (
 
 from fas.models import AccountPermissionType as perm
 
-from fas.utils import format_datetime, fix_utc_iso_format
+from fas.utils import format_datetime, utc_iso_format
 
 import datetime
 
@@ -158,7 +158,7 @@ class People(Base):
                 'Ircnick': self.ircnick,
                 'Avatar': self.avatar,
                 'Email': self.email,
-                'CreationDate': fix_utc_iso_format(self.date_created),
+                'CreationDate': utc_iso_format(self.date_created),
                 'Status': self.status
             }
 

--- a/fas/utils/__init__.py
+++ b/fas/utils/__init__.py
@@ -74,3 +74,18 @@ def format_datetime(locale, tdatetime):
 
         return tdatetime
 
+def fix_utc_iso_format(utc):
+    '''Python's built in isoformat method for UTC datetime objects is,
+    despite its name, not really ISO format. It breaks the specification which
+    requires that if there is no timezone suffix, the time should be considered
+    local (not UTC) time. By default, datetime objects don't carry any timezone
+    information at all. So, here we format it ourselves to format it in the
+    right way, but we have no guarantee that the thing passed is actually a
+    *UTC* time as opposed to a local time, so this could very easily generate
+    bad output. In a typed environment this issue would be eliminated.
+
+    This change, as long as it's only applied to actual UTC times, results in
+    being able to parse the time correctly in environments which do follow the
+    specification.'''
+    strftime = '%Y-%m-%dT%H:%M:%SZ'
+    return utc.strftime(strftime)

--- a/fas/utils/__init__.py
+++ b/fas/utils/__init__.py
@@ -74,7 +74,7 @@ def format_datetime(locale, tdatetime):
 
         return tdatetime
 
-def fix_utc_iso_format(utc):
+def utc_iso_format(utc):
     '''Python's built in isoformat method for UTC datetime objects is,
     despite its name, not really ISO format. It breaks the specification which
     requires that if there is no timezone suffix, the time should be considered


### PR DESCRIPTION
See the comment above `fix_utc_iso_format` in `fas/utils/__init__.py`,
but the general idea is that Python's datetime carries no timezone
information. So when it's used for UTC, it breaks the
specification (which says that it, if no `Z` or `+HHMM` or `-HHMM` is
specified, then the time should be treated as local time).

Furthermore, since it's invalid, it makes it impossible to correctly
parse in environments which are more strict about following the ISO
format, since such environments are timezone-aware and won't know which
timezone to tag the timestamp with.

Note that this fix is very unideal: Since Python is unityped, there's no
way to ensure that the object passed to `fix_utc_iso_format` is really a
UTC time. This means that if a local time is passed to
`fix_utc_iso_format`, we will once again break the ISO spec and render
it as a UTC timestamp. (If it's not a `datetime` object at all, who
knows what runtime error will happen, but this issue is everywhere in
Python, not specific to `fix_utc_iso_format`.)

Signed-off-by: Ricky Elrod <ricky@elrod.me>