### PR TITLE
Also publish fedmsg when yubikey updated via json api.

### DIFF
--- a/plugins/fas-plugin-yubikey/fas_yubikey/__init__.py
+++ b/plugins/fas-plugin-yubikey/fas_yubikey/__init__.py
@@ -235,7 +235,13 @@ class YubikeyPlugin(controllers.Controller):
         except IndexError:
             # No old record?  Maybe they never used their key
             pass
-            
+
+        fas.fedmsgshim.send_message(topic='user.update', msg={
+            'agent': username,
+            'user': username,
+            'fields': ['yubikey'],
+        })
+
         string = "%s %s %s" % (publicname, internalname, aeskey)
         return dict(key=string)
 


### PR DESCRIPTION
Previously, code was added to publish fedmsg messages when the user
updated their yubikey through the web interface.

This adds the same message to the JSON interface, so that
fedora-burn-yubikey usage will kick off the message.