### PR TITLE
Update export-bugzilla so that it does not to store the token file on disc

### DIFF
--- a/scripts/export-bugzilla.py
+++ b/scripts/export-bugzilla.py
@@ -46,7 +46,7 @@ if __name__ == '__main__':
     bzGroup = args[1]
 
     server = bugzilla.Bugzilla(url=BZSERVER, user=BZUSER, password=BZPASS,
-            cookiefile=None)
+            cookiefile=None, tokenfile=None)
     bugzilla_queue = BugzillaQueue.query.join('group').filter_by(
             name=ourGroup)
 


### PR DESCRIPTION
We are not storing token file on disc as we were not storing cookie file on disc