### PR TITLE
Fix reference to missing field by adding the field

### DIFF
--- a/fas/security.py
+++ b/fas/security.py
@@ -190,6 +190,7 @@ class LoginStatus(IntEnum):
     SUCCEED_NEED_APPROVAL = 0x02
     FAILED_INACTIVE_ACCOUNT = 0x03
     FAILED_LOCKED_ACCOUNT = 0x04
+    PENDING_ACCOUNT = 0x05
 
 
 def process_login(request, person, password):


### PR DESCRIPTION
This fixes a fatal that occurs when you attempt to log in using an account that is in pending state.