### PR TITLE
Add fedmenu!

### DIFF
--- a/development.ini
+++ b/development.ini
@@ -126,6 +126,14 @@ email.smtp.server = localhost
 email.from = Fedora Account System <noreply@fedoraproject.org>
 
 
+###
+# Fedmenu stuff
+###
+
+fedmenu.url = https://apps.fedoraproject.org/fedmenu
+fedmenu.data_url = https://apps.fedoraproject.org/js/data.js
+
+
 [app:plugins]
 
 ###

--- a/fas/templates/fedoraproject/site.xhtml
+++ b/fas/templates/fedoraproject/site.xhtml
@@ -148,5 +148,20 @@
         </div>
     </div>
 
+    % if 'fedmenu.url' in request.registry.settings:
+    <script src="${request.registry.settings.get('fedmenu.url')}/js/fedora-libravatar.js"></script>
+    <script src="${request.registry.settings.get('fedmenu.url')}/js/fedmenu.js"></script>
+    <script>
+      fedmenu({
+          'url': '${request.registry.settings.get("fedmenu.data_url")}',
+          'mimeType': 'application/javascript',
+          'position': 'bottom-right',
+          % if person:
+            'user': '${person.username}',
+          % endif
+      });
+    </script>
+    % endif
+
   </body>
 </html>


### PR DESCRIPTION
This will add a little menu on the bottom right hand corner of the
screen to link the user to other apps in Fedora Infrastructure.
If the fedmenu.url value is not defined in the config, then nothing is
display (so FAS can be reused other places that don't want to use this
shim).

As a nice bonus, on user profile pages we'll also display a little
button with their avatar than takes you to views of that user in other
infra apps (so you can quickly jump to see what packages they own or
what their datagrepper activity is, etc..).