### PR TITLE
Fix initializing choices on load

### DIFF
--- a/fas/forms/group.py
+++ b/fas/forms/group.py
@@ -104,8 +104,16 @@ class EditGroupForm(Form):
     license_sign_up = SelectField(
         _(u'License requirement'),
         [validators.Optional()],
-        coerce=int,
-        choices=[(l.id, l.name) for l in provider.get_licenses()])
+        coerce=int)
+
+    def __init__(self, *args, **kwargs):
+        super(EditGroupForm, self).__init__(*args, **kwargs)
+        # Initialize choices here so we load this every time instead of
+        # upon startup
+        self.license_sign_up.choices = [
+            (l.id, l.name)
+            for l in provider.get_licenses()
+        ]
 
 
 class GroupAdminsForm(Form):

--- a/fas/forms/people.py
+++ b/fas/forms/people.py
@@ -98,12 +98,17 @@ class PeopleForm(Form):
     people = SelectField(
         _(u'Select a user'),
         [validators.Required()],
-        coerce=int,
-        choices=[
+        coerce=int
+    )
+
+    def __init__(self, *args, **kwargs):
+        super(PeopleForm, self).__init__(*args, **kwargs)
+        # Initialize choices here so we load this every time instead of
+        # upon startup
+        self.people.choices = [
             (u.id, u.username + ' (' + u.fullname + ')')
             for u in provider.get_people()
         ]
-    )
 
 
 class UsernameForm(Form):


### PR DESCRIPTION
This makes sure the options for certain forms are loaded as needed instead of on start of the web app.

Signed-off-by: Patrick Uiterwijk <puiterwijk@redhat.com>