### PR TITLE
Allow to specify a status for the list call

### DIFF
--- a/fas/user.py
+++ b/fas/user.py
@@ -600,16 +600,14 @@ If this is not expected, please contact admin@fedoraproject.org and let them kno
     #@validate(validators=UserList())
     @identity.require(identity.not_anonymous())
     @expose(template="fas.templates.user.list", allow_json=True)
-    def list(self, search=u'a*', fields=None, limit=None,
-             return_non_active=False):
+    def list(self, search=u'a*', fields=None, limit=None, status=None):
         '''List users
 
         :kwarg search: Limit the users returned by the search string.  * is a
             wildcard character.
         :kwarg fields: Fields to return in the json request.  Default is
             to return everything.
-        :kwargs return_non_active: Whether to return accounts with status
-            not "active"
+        :kwargs status: if specified, only returns accounts with this status.
 
         This should be fixed up at some point.  Json data needs at least the
         following for fasClient to work::
@@ -670,8 +668,8 @@ If this is not expected, please contact admin@fedoraproject.org and let them kno
                     onclause=PersonRolesTable.c.group_id==GroupsTable.c.id)
         stmt = select([joined_roles]).where(People.username.ilike(re_search))\
                 .order_by(People.username).limit(limit)
-        if return_non_active is False:
-            stmt = stmt.where(People.status=='active')
+        if status is not None:
+            stmt = stmt.where(People.status==status)
         stmt.use_labels = True
         people = stmt.execute()
 


### PR DESCRIPTION
This patch allows API clients to request to receive only uesrs
with a specific status.

Signed-off-by: Patrick Uiterwijk <puiterwijk@redhat.com>