### PR TITLE
Validate email the same way turbomail does it

### DIFF
--- a/fas/user.py
+++ b/fas/user.py
@@ -88,7 +88,7 @@ from fas.auth import (
 from fas.util import available_languages
 from fas.validators import KnownUser, PasswordStrength, ValidGPGKeyID, \
     ValidSSHKey, NonFedoraEmail, ValidLanguage, UnknownUser, ValidUsername, \
-    ValidHumanWithOverride, MaybeFloat
+    ValidHumanWithOverride, MaybeFloat, EVEmail
 from fas import _
 
 #ADMIN_GROUP = config.get('admingroup', 'accounts')
@@ -112,10 +112,12 @@ class UserCreate(validators.Schema):
     email = validators.All(
         validators.Email(not_empty=True, strip=True),
         NonFedoraEmail(not_empty=True, strip=True),
+        EVEmail(not_empty=True, strip=True),
     )
     verify_email = validators.All(
         validators.Email(not_empty=True, strip=True),
         NonFedoraEmail(not_empty=True, strip=True),
+        EVEmail(not_empty=True, strip=True),
     )
     security_question = validators.UnicodeString(not_empty=True)
     security_answer = validators.UnicodeString(not_empty=True)
@@ -159,6 +161,7 @@ class UserSave(validators.Schema):
     email = validators.All(
        validators.Email(not_empty=True, strip=True, max=128),
        NonFedoraEmail(not_empty=True, strip=True, max=128),
+       EVEmail(not_empty=True, strip=True, max=128),
     )
     locale = ValidLanguage(not_empty=True, strip=True)
     #fedoraPersonBugzillaMail = validators.Email(strip=True, max=128)

--- a/fas/validators.py
+++ b/fas/validators.py
@@ -36,6 +36,7 @@
 import re
 
 from turbogears import validators, config
+from turbomail.email_validator import EmailValidator
 from sqlalchemy.exc import InvalidRequestError
 from fas.util import available_languages
 
@@ -174,6 +175,22 @@ class NonFedoraEmail(validators.FancyValidator):
         # pylint: disable-msg=C0111
         if value.endswith('@fedoraproject.org'):
             raise validators.Invalid(self.message('no_loop', state), value, state)
+
+class EVEmail(validators.FancyValidator):
+    '''Verify that turbomail accepts this email address'''
+    messages = {'invalid': _('Your email address is invalid')}
+
+    def _to_python(self, value, state):
+        # pylint: disable-msg=C0111,W0613
+        return value.strip()
+
+    def validate_python(self, value, state):
+        # pylint: disable-msg=C0111
+        ev = EmailValidator()
+        try:
+            ev.validate_or_raise(value)
+        except:
+            raise validators.Invalid(self.message('invalid', state), value, state)
 
 class MaybeFloat(validators.FancyValidator):
     ''' Make sure the float value is a valid float value (or None) '''


### PR DESCRIPTION
This email validation is the same check the library we use for
sending email (turbomail) uses.
Currently, it is possible to get email addresses like whatever.@domain.com
(note the . before @) into FAS, and we will crash as soon as we
try to send an actual email.

Signed-off-by: Patrick Uiterwijk <puiterwijk@redhat.com>