### PR TITLE
Updating readme to add missing dependencies

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,10 +15,12 @@ Setup virtualenvwrapper
 -----------------------
 ``sudo yum -y install python-virtualenvwrapper``
 
-Add the following to your `~/.zshrc`::
+Add the following to your `~/.zshrc` or `~/.bashrc`::
 
     export WORKON_HOME=$HOME/.virtualenvs
     source /usr/bin/virtualenvwrapper.sh
+
+Once finished run this command `source ~/.zshrc` or `source ~/.bashrc` for which ever shell you use.
 
 Bootstrap the virtualenv
 ------------------------
@@ -38,7 +40,7 @@ Fedora OS
 
 ::
 
-    sudo dnf install -y libffi-devel openssl-devel GeoIP-devel libyaml-devel
+    sudo dnf install -y libffi-devel openssl-devel GeoIP-devel libyaml-devel redhat-rpm-config libjpeg-turbo-devel
 
     sudo dnf install -y aajohan-comfortaa-fonts abattis-cantarell-fonts
     # if you want to use system fonts
@@ -70,4 +72,3 @@ Migrating FAS from release 2.x
 Run the web app
 ---------------
 ``pserve development.ini --reload``
-


### PR DESCRIPTION
On a fresh install there is missing dependencies. Also added additional information after appending info to shells rc file
```
Collecting cffi>=1.4.1 (from cryptography->fas==3.0.0)
  Downloading cffi-1.6.0.tar.gz (397kB)
    100% |████████████████████████████████| 399kB 1.2MB/s 
    Complete output from command python setup.py egg_info:
    gcc: error: /usr/lib/rpm/redhat/redhat-hardened-cc1: No such file or directory
    gcc: error: /usr/lib/rpm/redhat/redhat-hardened-cc1: No such file or directory
```
and
```
  Failed building wheel for pillow
...
...
...
        ' using --disable-%s, aborting' % (f, f))
    ValueError: jpeg is required unless explicitly disabled using --disable-jpeg, aborting

    ----------------------------------------
Command "/home/skrzepto/.virtualenvs/fas-python2.7/bin/python2.7 -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-32SxGC/pillow/setup.py';exec(compile(getattr(tokenize, 'open', open)(__file__).read().replace('\r\n', '\n'), __file__, 'exec'))" install --record /tmp/pip-4PRI7m-record/install-record.txt --single-version-externally-managed --compile --install-headers /home/skrzepto/.virtualenvs/fas-python2.7/include/site/python2.7/pillow" failed with error code 1 in /tmp/pip-build-32SxGC/pillow/
```