### PR TITLE
Replace last_logged attribute by the login_timestamp

### DIFF
--- a/fas/subscribers/login.py
+++ b/fas/subscribers/login.py
@@ -98,7 +98,7 @@ def onLoginSucceeded(event):
         person.login_attempt = 0
         register.add_people(person)
 
-    person.last_logged = datetime.datetime.utcnow()
+    person.login_timestamp = datetime.datetime.utcnow()
 
     register.save_account_activity(request, person.id,
                                    AccountLogType.LOGGED_IN.value)

--- a/fas/subscribers/people.py
+++ b/fas/subscribers/people.py
@@ -37,7 +37,7 @@ def on_password_change_requested(event):
     """ Check that user is allowed to get through. """
     person = event.person
     curr_dtime = datetime.datetime.utcnow()
-    last_dtime = person.last_logged
+    last_dtime = person.login_timestamp
     delta = (curr_dtime - last_dtime).seconds
 
     log.debug('Checking current time %s against last login\'s time %s' %


### PR DESCRIPTION
People model doesn't have `last_logged` attribute, but has a `login_timestamp`.
Updated old reference to `last_logged` with the `login_timestamp`