### PR TITLE
Allow accessing group profile by their name instead of id

### DIFF
--- a/fas/templates/fedoraproject/groups/details.xhtml
+++ b/fas/templates/fedoraproject/groups/details.xhtml
@@ -77,6 +77,8 @@
           <div class="centered text-center col-sm-7 col-md-6">
               <h3></h3>
               <dl class="dl-horizontal">
+                  <dt>${_(u'Group Name')}</dt>
+                  <dd>${group.name}</dd>
                   %if group.web_link:
                       <dt>${_(u'Web page')}</dt>
                       <dd>${group.web_link}</dd>


### PR DESCRIPTION
And first check if there is a group, then retrieve its members, otherwise
we end up with no group found, not because it doesn't exist but because
there are no members anymore.