### PR TITLE
Fix ssh key updating

### DIFF
--- a/fas/validators.py
+++ b/fas/validators.py
@@ -251,7 +251,7 @@ class ValidSSHKey(validators.FancyValidator):
             if not keyline:
                 continue
             keyline = keyline.strip()
-            validline = re.match('^({}) [ \t]*[^ \t]+.*$'.format(valid_ssh_key), keyline)
+            validline = re.match('^({0}) [ \t]*[^ \t]+.*$'.format(self.valid_ssh_key), keyline)
             if not validline:
                 raise validators.Invalid(self.message('invalid_key', state,
                         key=keyline), value, state)


### PR DESCRIPTION
The valid_ssh_key is not a global, but instance-local.
Also, {} is python 2.7-only syntax, while we run on RHEL6, which has python 2.6.

Signed-off-by: Patrick Uiterwijk <puiterwijk@redhat.com>