### PR TITLE
If the list of local.available is empty we should be able to cope with it

### DIFF
--- a/fas/util.py
+++ b/fas/util.py
@@ -53,7 +53,7 @@ class Config(object):
         config = None
 
         try:
-            config = settings[configname] or default_config
+            config = settings.get(configname) or default_config
         except TypeError:
             # We might hit this if we call registry too soon when initializing
             pass

--- a/fas/views/people.py
+++ b/fas/views/people.py
@@ -308,7 +308,7 @@ class People(object):
             if c[0] not in Config.get('blacklist.country')]
 
         form.locale.choices = [
-            (l, l) for l in list(Config.get('locale.available').split(','))]
+            (l, l) for l in list(Config.get('locale.available', '').split(','))]
 
         if self.request.method == 'POST' \
                 and ('form.save.person-infos' in self.request.params):


### PR DESCRIPTION
There was two problem:
- settings[configname] raises a KeyError if the key isn't in the settings,
so the second part of the line `or default_config` is never used.
We fixed this.

- Config.get('locale.available') returns None if there are no
locale.available, but None cannot be split, so instead we make sure that
if there are no locale.available we get an empty string which can be
split.