### PR TITLE
show the currently logged in user in the groups user list

### DIFF
--- a/fas/views/groups.py
+++ b/fas/views/groups.py
@@ -208,6 +208,7 @@ class Groups(object):
                 authenticated_membership = membership
                 if membership.status == MembershipStatus.APPROVED:
                     is_member = True
+                    members.append(membership)
 
         if authenticated:
             if authenticated.id == group.owner_id \

--- a/fas/views/groups.py
+++ b/fas/views/groups.py
@@ -192,23 +192,20 @@ class Groups(object):
 
         for grp, membership, member in g_memberships:
             memberships.append(membership)
-            if authenticated != member:
-                if membership.status == MembershipStatus.APPROVED \
-                        and member.status in valid_active_status:
-                    if membership.role == MembershipRole.USER:
-                        user_members.append(membership)
-                    elif membership.role == MembershipRole.SPONSOR \
-                            and grp.requires_sponsorship:
-                        sponsor_members.append(membership)
-                    elif membership.role == MembershipRole.ADMINISTRATOR:
-                        admin_members.append(membership)
-                    members.append(membership)
-            else:
-                authenticated = member
+            if authenticated == member:
                 authenticated_membership = membership
-                if membership.status == MembershipStatus.APPROVED:
+            if membership.status == MembershipStatus.APPROVED \
+                    and member.status in valid_active_status:
+                if membership.role == MembershipRole.USER:
+                    user_members.append(membership)
+                elif membership.role == MembershipRole.SPONSOR \
+                        and grp.requires_sponsorship:
+                    sponsor_members.append(membership)
+                elif membership.role == MembershipRole.ADMINISTRATOR:
+                    admin_members.append(membership)
+                if authenticated == member:
                     is_member = True
-                    members.append(membership)
+                members.append(membership)
 
         if authenticated:
             if authenticated.id == group.owner_id \


### PR DESCRIPTION
fixes: #187

Previously, if a user is logged in and looking at a group that
they are a member of, they would not be shown in the members list

This makes the user shown in the list of all the users for the current
group