### PR TITLE
make group admin controls show if you are a group admin

### DIFF
--- a/fas/security.py
+++ b/fas/security.py
@@ -472,11 +472,7 @@ class MembershipValidator(Base):
     """ Validate membership from given group and username"""
 
     def __init__(self, person_username, group):
-        if type(group) is str or unicode:
-            self.group = [group]
-            # self.group.append(group)
-        if type(group) is list:
-            self.group = group
+        self.group = group
         self.username = person_username
         super(MembershipValidator, self).__init__()
 
@@ -494,7 +490,13 @@ class MembershipValidator(Base):
         log.debug('checking group membership %s against %s'
                       % (groups, self.group))
         log.debug(groups.intersection(set(self.group)))
-        if len(groups.intersection(set(self.group))) > 0:
+
+        if isinstance(self.group, basestring):
+            groupset = set([self.group])
+        else:
+            groupset = set(self.group)
+
+        if len(groups.intersection(groupset)) > 0:
             log.debug('Granting access')
             return True
 


### PR DESCRIPTION
the init method of the MembershipValidator class previously had some lines in it that converted self.group to a list if it was of str or unicode type, rather than a list:

    if type(group) is str or unicode:
        self.group = [group]
        # self.group.append(group)
    if type(group) is list:
        self.group = group

Based on my limited knowledge of class inheritance, it appears that these conversions were overwritten my the init function in the `RoleValidator` class. So when the validate method in the MembershipValidator class tried to perform the intersections of the sets to see if the groupname was in the list of permitted groups, self.group was not a list anymore, and always returned False.

This commit moves the logic of converting str and unicode types into the validate method of MembershipValidator, and fixes the symptoms described in Issue #229