### PR TITLE
show groupname instead of None if no displayname is set

### DIFF
--- a/fas/theme/default/templates/people/profile.xhtml
+++ b/fas/theme/default/templates/people/profile.xhtml
@@ -149,7 +149,7 @@
               <div class="col-sm-6 col-sm-4 col-lg-4">
                   <a href="${request.route_url('group-details', id=g.group.id)}">
                       <img src="${request.static_url('%s/assets/fedora_35.png' % theme_static)}">
-                      ${g.group.display_name}
+                      ${g.group.display_name or g.group.name}
                   </a> -
                   <span>${g.get_role().name.lower()}</span>
               </div>


### PR DESCRIPTION
Fixes issue #231 

Previously, if a group did not have a displayname set, the involvement section in a user's profile page would show "None" rather than the group's name. Now if a displayname for a group is not set, it falls back to use the group's name.