### PR TITLE
return a 400 if page 0 or a negative page is requested

### DIFF
--- a/fas/views/groups.py
+++ b/fas/views/groups.py
@@ -69,9 +69,9 @@ class Groups(object):
 
         pages = compute_list_pages_from(groups_cnt, 50)
 
-        if page > pages:
+        if page > pages or page < 1:
             return HTTPBadRequest(
-                'The page is bigger than the maximum number of pages')
+                'The page is outside the valid number of pages')
 
         return dict(
             groups=groups,

--- a/fas/views/people.py
+++ b/fas/views/people.py
@@ -82,9 +82,9 @@ class People(object):
 
         pages = compute_list_pages_from(peoples, 50)
 
-        if page > pages:
+        if page > pages or page < 1:
             return HTTPBadRequest(
-                'The page is bigger than the maximum number of pages')
+                'The page is outside the valid number of pages')
 
         return dict(
             people=people,


### PR DESCRIPTION
Previously it was possible with the pagination URLs on the people and groups lists to request page 0 or a negative page, for example:

https://admin.stg.fedoraproject.org/fas3/groups/page/-4
https://admin.stg.fedoraproject.org/fas3/people/page/0

this change detects if a page under 1 is requested on the groups list and the users list, and returns the 400 error as was previously done if the number of pages exceeded the available number of pages.