### PR TITLE
make CAPTCHA render

### DIFF
--- a/fas/lib/captcha.py
+++ b/fas/lib/captcha.py
@@ -100,7 +100,7 @@ class Captcha(Config):
 
         img = Image.new('RGB', image_size)
 
-        img.paste(self.bg_color)
+        img.paste(self.bg_color, (0,0)+image_size)
 
         try:
             font = ImageFont.truetype(self.font_path, self.font_size)


### PR DESCRIPTION
previously, the CAPTCHA was not rendering when on the
create new account page. The error message from PIL
suggested using the 4-tuple of the image size in the
paste call, so that is what this does, and it fixes the
issue.

Fixes: Issue #244 