### PR TITLE
fix account verification process

### DIFF
--- a/fas/notifications/email.py
+++ b/fas/notifications/email.py
@@ -70,5 +70,8 @@ def on_notification_request(event):
         except socket_error, e:
             log.error('Unable to send email: %s', str(e))
             event.request.session.flash(_('%s' % error_msg))
+
+        log.debug("Email:\nSubject:%s\nTo:%s\nMessage:%s" % (subject, recipient, body))
+
     else:
         log.warn('Unable to send out email, could not found email message.')

--- a/fas/views/register.py
+++ b/fas/views/register.py
@@ -141,8 +141,8 @@ class Register(object):
             raise HTTPNotFound('No user found with this token')
 
         self.person.password_token = None
-        self.person.status = AccountStatus.ACTIVE
+        self.person.status = AccountStatus.ACTIVE.value
         register.add_people(self.person)
         self.request.session.flash(_('Account activated'), 'info')
 
-        return redirect_to('/people/profile/%s' % self.person.id)
+        return redirect_to(self.request, 'people-profile', id=self.person.id)


### PR DESCRIPTION
* First up, this adds a debug message so that when you are testing account verification, the email that is sent is diplayed as a debug message, so you can get at the verification URL

* Next, it fixes the redirect_to, which requires at least 2 arguments, but we were only providing one.

* Finally, after fixing the redirect_to issue, the following error appeared when trying to verify an account:

```
ProgrammingError: (psycopg2.ProgrammingError) missing FROM-clause entry for table "accountstatus"
LINE 1: UPDATE people SET password_token=NULL, status=AccountStatus....
                                                      ^
 [SQL: 'UPDATE people SET password_token=%(password_token)s, status=%(status)s, update_timestamp=CURRENT_TIMESTAMP WHERE people.id = %(people_id)s'] [parameters: {'status': <AccountStatus.ACTIVE: 1>, 'people_id': 10007, 'password_token': 
None}]
```

changing 
```
self.person.status = AccountStatus.ACTIVE
```
to 
```
self.person.status = AccountStatus.ACTIVE.value
```

fixed this issue