### PR TITLE
Add two IRC-related fields to the people model

### DIFF
--- a/alembic/versions/b6109e69f4d8_added_irc_enabled_and_irc_password.py
+++ b/alembic/versions/b6109e69f4d8_added_irc_enabled_and_irc_password.py
@@ -1,0 +1,26 @@
+"""Added 'irc_enabled' and 'irc_password' fields to People
+
+Revision ID: b6109e69f4d8
+Revises: c3f6e45190ca
+Create Date: 2017-01-27 17:54:27.841432
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'b6109e69f4d8'
+down_revision = 'c3f6e45190ca'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('people', sa.Column('irc_enabled', sa.Boolean(), default=False))
+    op.add_column('people', sa.Column('irc_password', sa.UnicodeText(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('people', 'irc_password')
+    op.drop_column('people', 'irc_enabled')

--- a/fas/models/people.py
+++ b/fas/models/people.py
@@ -107,6 +107,8 @@ class People(Base):
     password = Column(UnicodeText(), nullable=False)
     fullname = Column(UnicodeText(), nullable=False)
     ircnick = Column(UnicodeText(), unique=True, nullable=True)
+    irc_enabled = Column(Boolean, default=False)
+    irc_password = Column(UnicodeText(), nullable=True)
     avatar = Column(UnicodeText(), nullable=True)
     avatar_id = Column(Unicode, nullable=True)
     introduction = Column(UnicodeText(), nullable=True)


### PR DESCRIPTION
Fedora Hubs wants to offer an easy IRC experience for users who opt in
to it. This adds two fields to the ``People`` model. ``irc_enabled`` is
the flag to indicate whether the user wants to use the Fedora-provided
IRC bouncer, and ``irc_password`` is the Freenode password used to
identify the user. ``ircnick`` will be used to determine the nick to use
and ``email`` can be used for the registration email.

For more context, see:

* https://pagure.io/fedora-hubs/issue/2
* https://pagure.io/fedora-hubs/issue/290
* https://pagure.io/fedora-hubs/issue/291

Do I need to add tests, and if so, where?